### PR TITLE
Simplify working with subscription

### DIFF
--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -1,101 +1,53 @@
-import { cborToLexRecord, readCar } from '@atproto/repo'
 import { ids, lexicons } from './lexicon/lexicons'
 import { Record as PostRecord } from './lexicon/types/app/bsky/feed/post'
 import {
-  Commit,
   OutputSchema as RepoEvent,
   isCommit,
 } from './lexicon/types/com/atproto/sync/subscribeRepos'
-import { PostTable } from './db'
-import { FirehoseSubscriptionBase } from './util/subscription'
+import {
+  FirehoseSubscriptionBase,
+  getPostOperations,
+} from './util/subscription'
 
 export class FirehoseSubscription extends FirehoseSubscriptionBase {
   async handleEvent(evt: RepoEvent) {
     if (!isCommit(evt)) return
-    const postEvts = await getPostEventsFromEvt(evt)
-    const toDelete: string[] = []
-    const toCreate: PostTable[] = []
-    for (const evt of postEvts) {
-      if (evt.type === 'delete') {
-        toDelete.push(evt.uri)
-      } else {
-        // only alf related posts
-        if (evt.text.toLowerCase().includes('alf')) {
-          toCreate.push({
-            uri: evt.uri,
-            cid: evt.cid,
-            replyParent: evt.replyParent ?? null,
-            replyRoot: evt.replyRoot ?? null,
-            indexedAt: new Date().toISOString(),
-          })
+    const postOps = await getPostOperations(evt)
+    const postsToDelete = postOps.deletes.map((del) => del.uri)
+    const postsToCreate = postOps.creates
+      .filter((create) => {
+        // only alf-related posts
+        return (
+          isPost(create.record) &&
+          create.record.text.toLowerCase().includes('alf')
+        )
+      })
+      .map((create) => {
+        // map alf-related posts to a db row
+        const record = isPost(create.record) ? create.record : null
+        return {
+          uri: create.uri,
+          cid: create.cid,
+          replyParent: record?.reply?.parent.uri ?? null,
+          replyRoot: record?.reply?.root.uri ?? null,
+          indexedAt: new Date().toISOString(),
         }
-      }
+      })
+
+    if (postsToDelete.length > 0) {
+      await this.db
+        .deleteFrom('posts')
+        .where('uri', 'in', postsToDelete)
+        .execute()
     }
-    if (toDelete.length > 0) {
-      await this.db.deleteFrom('posts').where('uri', 'in', toDelete).execute()
-    }
-    if (toCreate.length > 0) {
+    if (postsToCreate.length > 0) {
       await this.db
         .insertInto('posts')
-        .values(toCreate)
+        .values(postsToCreate)
         .onConflict((oc) => oc.doNothing())
         .execute()
     }
   }
-}
-
-type PostEvent = CreatePost | DeletePost
-
-type CreatePost = {
-  type: 'create'
-  uri: string
-  cid: string
-  author: string
-  text: string
-  replyRoot?: string
-  replyParent?: string
-}
-
-type DeletePost = {
-  type: 'delete'
-  uri: string
-}
-
-const getPostEventsFromEvt = async (evt: Commit): Promise<PostEvent[]> => {
-  const postOps = evt.ops.filter(
-    (op) => op.path.split('/')[1] === 'app.bsky.feed.post',
-  )
-  if (postOps.length < 1) return []
-
-  const car = await readCar(evt.blocks)
-
-  const postEvts: PostEvent[] = []
-  for (const op of postOps) {
-    // updates not supported yet
-    if (op.action === 'update') continue
-    const uri = `at://${evt.repo}/${op.path}`
-    if (op.action === 'delete') {
-      postEvts.push({ type: 'delete', uri })
-    } else if (op.action === 'create') {
-      if (!op.cid) continue
-      const postBytes = await car.blocks.get(op.cid)
-      if (!postBytes) continue
-
-      const record = cborToLexRecord(postBytes)
-      if (!isPost(record)) continue
-      await lexicons.assertValidRecord(ids.AppBskyFeedPost, record)
-      postEvts.push({
-        type: 'create',
-        uri,
-        cid: op.cid.toString(),
-        author: evt.repo,
-        text: record.text,
-        replyRoot: record.reply?.root.uri,
-        replyParent: record.reply?.parent.uri,
-      })
-    }
-  }
-  return postEvts
 }
 
 export const isPost = (obj: unknown): obj is PostRecord => {


### PR DESCRIPTION
This breaks-out some of the ugly wiring around subscriptions from the implementation details of the feed generator.  Should make it a little friendlier to author feed generators without having to understand how the subscription works.