### PR TITLE
Fix feed generation cursor split (#15)

### DIFF
--- a/src/feed-generation.ts
+++ b/src/feed-generation.ts
@@ -28,7 +28,7 @@ export default function (server: Server, ctx: AppContext) {
       .orderBy('cid', 'desc')
 
     if (params.cursor) {
-      const [indexedAt, cid] = params.cursor.split('..')
+      const [indexedAt, cid] = params.cursor.split('::')
       if (!indexedAt || !cid) {
         throw new InvalidRequestError('malformed cursor')
       }


### PR DESCRIPTION
Fixes #15. It is assumed the ".." is a typo, as "::" matches cursor repo on other things, such as com.atproto.sync.listRepos.