### PR TITLE
Fix `feed` query parameter not using `at-uri`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once the custom algorithms feature launches, you'll be able to publish your feed
 
 ## Running the Server
 
-Install dependencies with `yarn` and then run the server with `yarn start`. This will start the server on port 3000, or what's defined in `.env`. You can then watch the firehose output in the console and access the output of the default custom ALF feed at [http://localhost:3000/xrpc/app.bsky.feed.getFeedSkeleton?feed=did:example:alice/app.bsky.feed.generator/whats-alf](http://localhost:3000/xrpc/app.bsky.feed.getFeedSkeleton?feed=did:example:alice/app.bsky.feed.generator/whats-alf).
+Install dependencies with `yarn` and then run the server with `yarn start`. This will start the server on port 3000, or what's defined in `.env`. You can then watch the firehose output in the console and access the output of the default custom ALF feed at [http://localhost:3000/xrpc/app.bsky.feed.getFeedSkeleton?feed=at://did:example:alice/app.bsky.feed.generator/whats-alf](http://localhost:3000/xrpc/app.bsky.feed.getFeedSkeleton?feed=at://did:example:alice/app.bsky.feed.generator/whats-alf).
 
 ## Some Details
 

--- a/src/feed-generation.ts
+++ b/src/feed-generation.ts
@@ -5,7 +5,7 @@ import { validateAuth } from './auth'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getFeedSkeleton(async ({ params, req }) => {
-    if (params.feed !== 'did:example:alice/app.bsky.feed.generator/whats-alf') {
+    if (params.feed !== 'at://did:example:alice/app.bsky.feed.generator/whats-alf') {
       throw new InvalidRequestError(
         'Unsupported algorithm',
         'UnsupportedAlgorithm',


### PR DESCRIPTION
Since https://github.com/bluesky-social/feed-generator/commit/bc753388c3c02cebeee961ec456cca07ec8bc19d the `app.bsky.feed.getFeedSkeleton` Lexicon has been using the `at-uri` format and not a string, breaking the current `feed` query parameter, this PR fixes that.

https://github.com/bluesky-social/feed-generator/blob/bc753388c3c02cebeee961ec456cca07ec8bc19d/src/lexicon/lexicons.ts#L4552-L4558