### PR TITLE
Change the default port to 443

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Whichever port you want to run this on 
-FEEDGEN_PORT=3000
+FEEDGEN_PORT=443
 
 # Change this to use a different bind address
 FEEDGEN_LISTENHOST="localhost"


### PR DESCRIPTION
As per #35, shouldn't the FEEDGEN_PORT environment variable be 443?