### PR TITLE
fix: handle firehose subscription reconnect on error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ FEEDGEN_PUBLISHER_DID="did:plc:abcde...."
 
 # Only use this if you want a service did different from did:web
 # FEEDGEN_SERVICE_DID="did:plc:abcde..."
+
+# Delay between reconnect attempts to the firehose subscription endpoint (in milliseconds)
+FEEDGEN_SUBSCRIPTION_RECONNECT_DELAY=3000

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,4 +15,5 @@ export type Config = {
   subscriptionEndpoint: string
   serviceDid: string
   publisherDid: string
+  subscriptionReconnectDelay: number
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ const run = async () => {
       'wss://bsky.social',
     publisherDid:
       maybeStr(process.env.FEEDGEN_PUBLISHER_DID) ?? 'did:example:alice',
+    subscriptionReconnectDelay:
+      maybeInt(process.env.FEEDGEN_SUBSCRIPTION_RECONNECT_DELAY) ?? 3000,
     hostname,
     serviceDid,
   })

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,7 +63,7 @@ export class FeedGenerator {
 
   async start(): Promise<http.Server> {
     await migrateToLatest(this.db)
-    this.firehose.run()
+    this.firehose.run(this.cfg.subscriptionReconnectDelay)
     this.server = this.app.listen(this.cfg.port, this.cfg.listenhost)
     await events.once(this.server, 'listening')
     return this.server


### PR DESCRIPTION
This PR allows the feed generator to try to reconnect back to the firehose subscription endpoint when an error occurred (Eg, WebSocket error 502).

(Close #44)

**Review and test process:**

1. Start a WebSocket server which simulates sending 502 error (change the port number as you like):
```javascript
import { WebSocketServer } from 'ws';

new WebSocketServer({
    port: 8080,
    verifyClient: (_info, callback) => {
        callback(false, 502);
    }
});
```

2. Start the WebSocket server on `FEEDGEN_SUBSCRIPTION_ENDPOINT` and confirm that the server doesn't crash.

3. Close the WebSocket server and confirm that the server doesn't crash.

4. Start a real firehose endpoint on `FEEDGEN_SUBSCRIPTION_ENDPOINT` and confirm that the server reconnects.