### PR TITLE
Fix initial cursor

### DIFF
--- a/src/util/subscription.ts
+++ b/src/util/subscription.ts
@@ -57,9 +57,9 @@ export abstract class FirehoseSubscriptionBase {
 
   async updateCursor(cursor: number) {
     await this.db
-      .updateTable('sub_state')
-      .set({ cursor })
-      .where('service', '=', this.service)
+      .insertInto('sub_state')
+      .values({ service: this.service, cursor })
+      .onConflict((oc) => oc.column('service').doUpdateSet({ cursor }))
       .execute()
   }
 


### PR DESCRIPTION
## Problem
When running for the first time, we only update the cursor but don't create the initial row, so it doesn't update anything.

## Solution
Changed the update to an upsert. Ran locally and verified `sub_state` was empty before, and after the change has a single row.