### PR TITLE
Remove agent.api.app.bsky.feed.describeFeedGenerator

### DIFF
--- a/scripts/publishFeedGen.ts
+++ b/scripts/publishFeedGen.ts
@@ -45,14 +45,6 @@ const run = async () => {
   const agent = new AtpAgent({ service: 'https://bsky.social' })
   await agent.login({ identifier: handle, password })
 
-  try {
-    await agent.api.app.bsky.feed.describeFeedGenerator()
-  } catch (err) {
-    throw new Error(
-      'The bluesky server is not ready to accept published custom feeds yet',
-    )
-  }
-
   let avatarRef: BlobRef | undefined
   if (avatar) {
     let encoding: string


### PR DESCRIPTION
This call appears to just be a gate to stop people publishing custom feeds before the feature was released.

Removed, and publishing appears to have no ill effect. Addresses #65 