### PR TITLE
Separate Subscription and Algorithm Functionality

### DIFF
--- a/src/algos/whats-alf.ts
+++ b/src/algos/whats-alf.ts
@@ -23,6 +23,7 @@ export const handler = async (ctx: AppContext, params: QueryParams) => {
       .where('post.indexedAt', '<', timeStr)
       .orWhere((qb) => qb.where('post.indexedAt', '=', timeStr))
       .where('post.cid', '<', cid)
+      .where('post.postText', 'like', '%alf%')
   }
   const res = await builder.execute()
 

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -17,6 +17,7 @@ migrations['001'] = {
       .addColumn('replyParent', 'varchar')
       .addColumn('replyRoot', 'varchar')
       .addColumn('indexedAt', 'varchar', (col) => col.notNull())
+      .addColumn('postText', 'varchar')
       .execute()
     await db.schema
       .createTable('sub_state')

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -18,10 +18,6 @@ export class FirehoseSubscription extends FirehoseSubscriptionBase {
 
     const postsToDelete = ops.posts.deletes.map((del) => del.uri)
     const postsToCreate = ops.posts.creates
-      .filter((create) => {
-        // only alf-related posts
-        return create.record.text.toLowerCase().includes('alf')
-      })
       .map((create) => {
         // map alf-related posts to a db row
         return {
@@ -30,6 +26,7 @@ export class FirehoseSubscription extends FirehoseSubscriptionBase {
           replyParent: create.record?.reply?.parent.uri ?? null,
           replyRoot: create.record?.reply?.root.uri ?? null,
           indexedAt: new Date().toISOString(),
+          postText: create.record.text.toLowerCase()
         }
       })
 


### PR DESCRIPTION
Currently the subscription performs the logic that should reside in the algorithm. Additionally, the current algorithm has nothing to do with text comparison, it just takes latest posts. It could just be called `latest-posts`.

Indexing posts is independent of generating content, and since `whats-alf` uses the text of the post, not other metadata, we should store text for this example