### PR TITLE
App password -> .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ FEEDGEN_PUBLISHER_DID="did:plc:abcde...."
 
 # Delay between reconnect attempts to the firehose subscription endpoint (in milliseconds)
 FEEDGEN_SUBSCRIPTION_RECONNECT_DELAY=3000
+
+# YOUR bluesky password, or preferably an App Password (found in your client settings)
+# Ex: abcd-1234-efgh-5678
+BLUESKY_APP_PASSWORD="APP_PASSWORD_HERE_PLZ"

--- a/scripts/publishFeedGen.ts
+++ b/scripts/publishFeedGen.ts
@@ -10,10 +10,6 @@ const run = async () => {
   // Ex: user.bsky.social
   const handle = ''
 
-  // YOUR bluesky password, or preferably an App Password (found in your client settings)
-  // Ex: abcd-1234-efgh-5678
-  const password = ''
-
   // A short name for the record that will show in urls
   // Lowercase with no spaces.
   // Ex: whats-hot
@@ -38,12 +34,17 @@ const run = async () => {
   if (!process.env.FEEDGEN_SERVICE_DID && !process.env.FEEDGEN_HOSTNAME) {
     throw new Error('Please provide a hostname in the .env file')
   }
+
+  if (!process.env.BLUESKY_APP_PASSWORD) {
+    throw new Error('Please set a Bluesky app password in the .env file')
+  }
+
   const feedGenDid =
     process.env.FEEDGEN_SERVICE_DID ?? `did:web:${process.env.FEEDGEN_HOSTNAME}`
 
   // only update this if in a test environment
   const agent = new AtpAgent({ service: 'https://bsky.social' })
-  await agent.login({ identifier: handle, password })
+  await agent.login({ identifier: handle, password: process.env.BLUESKY_APP_PASSWORD })
 
   let avatarRef: BlobRef | undefined
   if (avatar) {


### PR DESCRIPTION
Moved the app password needed for the publishing script to the .env file. Probably more secure by default? eg I foolishly commited my app password to a public git repo earlier today and then spent way too much time wrangling commit squashing.