### PR TITLE
Update copyright year and Bluesky's legal name in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Bluesky PBLLC
+Copyright (c) 2023–2024 Bluesky PBC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This small PR adds 2024 to the copyright statement and updates the legal name to Bluesky PBC in the LICENSE file.