### PR TITLE
Simplify db schema + pagination

### DIFF
--- a/src/algos/whats-alf.ts
+++ b/src/algos/whats-alf.ts
@@ -1,4 +1,3 @@
-import { InvalidRequestError } from '@atproto/xrpc-server'
 import { QueryParams } from '../lexicon/types/app/bsky/feed/getFeedSkeleton'
 import { AppContext } from '../config'
 
@@ -14,15 +13,8 @@ export const handler = async (ctx: AppContext, params: QueryParams) => {
     .limit(params.limit)
 
   if (params.cursor) {
-    const [indexedAt, cid] = params.cursor.split('::')
-    if (!indexedAt || !cid) {
-      throw new InvalidRequestError('malformed cursor')
-    }
-    const timeStr = new Date(parseInt(indexedAt, 10)).toISOString()
-    builder = builder
-      .where('post.indexedAt', '<', timeStr)
-      .orWhere((qb) => qb.where('post.indexedAt', '=', timeStr))
-      .where('post.cid', '<', cid)
+    const timeStr = new Date(parseInt(params.cursor, 10)).toISOString()
+    builder = builder.where('post.indexedAt', '<', timeStr)
   }
   const res = await builder.execute()
 
@@ -33,7 +25,7 @@ export const handler = async (ctx: AppContext, params: QueryParams) => {
   let cursor: string | undefined
   const last = res.at(-1)
   if (last) {
-    cursor = `${new Date(last.indexedAt).getTime()}::${last.cid}`
+    cursor = new Date(last.indexedAt).getTime().toString(10)
   }
 
   return {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -14,8 +14,6 @@ migrations['001'] = {
       .createTable('post')
       .addColumn('uri', 'varchar', (col) => col.primaryKey())
       .addColumn('cid', 'varchar', (col) => col.notNull())
-      .addColumn('replyParent', 'varchar')
-      .addColumn('replyRoot', 'varchar')
       .addColumn('indexedAt', 'varchar', (col) => col.notNull())
       .execute()
     await db.schema

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,8 +6,6 @@ export type DatabaseSchema = {
 export type Post = {
   uri: string
   cid: string
-  replyParent: string | null
-  replyRoot: string | null
   indexedAt: string
 }
 

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -27,8 +27,6 @@ export class FirehoseSubscription extends FirehoseSubscriptionBase {
         return {
           uri: create.uri,
           cid: create.cid,
-          replyParent: create.record?.reply?.parent.uri ?? null,
-          replyRoot: create.record?.reply?.root.uri ?? null,
           indexedAt: new Date().toISOString(),
         }
       })


### PR DESCRIPTION
This is meant as a simple "starter kit" for feed generators. There's a bit of unnecessary complexity in here that we can cut to demonstrate the concepts a bit more clearly.
- removing `replyParent` and `replyRoot` columns on the post table - these aren't currently used anywhere and it's unclear on first pass why they are being indexed
- use a simple timestamp cursor (as opposed to a timestamp::cid composite cursor) when paginating over the algorithm. Currently the algo logic looks more complex than it is mostly owing to this pagination logic