### PR TITLE
update deps: kysely@^0.27.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "better-sqlite3": "^8.3.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "kysely": "^0.22.0",
+    "kysely": "^0.27.4",
     "multiformats": "^9.9.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,10 +808,10 @@ iso-datestring-validator@^2.2.2:
   resolved "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz"
   integrity sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==
 
-kysely@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.npmjs.org/kysely/-/kysely-0.22.0.tgz"
-  integrity sha512-ZE3qWtnqLOalodzfK5QUEcm7AEulhxsPNuKaGFsC3XiqO92vMLm+mAHk/NnbSIOtC4RmGm0nsv700i8KDp1gfQ==
+kysely@^0.27.4:
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/kysely/-/kysely-0.27.4.tgz#96a0285467b380948b4de03b20d87e82d797449b"
+  integrity sha512-dyNKv2KRvYOQPLCAOCjjQuCk4YFd33BvGdf/o5bC7FiW+BB6snA81Zt+2wT9QDFzKqxKa5rrOmvlK/anehCcgA==
 
 lru-cache@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Kysely's `ExpressionBuilder` API and type definitions changed a bit, so current docs don't match the version installed here. This syntax is valid in the latest version of kysely (see [UpdateQueryBuilder#set](https://kysely-org.github.io/kysely-apidoc/classes/UpdateQueryBuilder.html#set)) but gets a TypeScript error in `0.22.0`:

```ts
        await this.db
          .updateTable('post')
          .set((eb) => ({
            likes: eb('likes', '+', 1)
          }))
          .where('uri', '=', like.postUri)
          .execute()
```

@devinivy 👋 