### PR TITLE
ci: add dependabot config with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+# Dependabot auto-update config.
+#
+# Cooldown (7 days) is the point of this config: it delays version-update
+# PRs until a newly-published version has aged. Supply-chain attacks like
+# the tanstack Shai-Hulud compromise (2026-05-11) live minutes-to-hours
+# before the registry yanks them; a 7-day cooldown keeps poisoned
+# versions out of our lockfiles.
+#
+# Security updates bypass cooldown and continue to flow immediately. See:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown
+#
+# Auto-merge is deliberately NOT enabled. Every dependabot PR gets human
+# review.
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      production:
+        dependency-type: production
+        update-types: [minor, patch]
+      development:
+        dependency-type: development
+        update-types: [minor, patch]


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` with a 7-day cooldown on version updates.

## Why

Org-wide rollout to help mitigate future supply chain attacks (cf. tanstack Shai-Hulud 2026-05-11). Contact @amckinley for details.

**Cooldown delays version-update PRs by 7 days. Security updates bypass cooldown** and continue to flow immediately.

## Config shape

- **weekly** schedule (Monday) — avoids daily PR noise
- **cooldown: 7 days**
- **grouped** by dependency-type (production / development), up to 5 open PRs
- **no auto-merge** — every dependabot PR still gets human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
